### PR TITLE
Add OP_CODE PUSH_NUM_1  

### DIFF
--- a/primitives/src/script.rs
+++ b/primitives/src/script.rs
@@ -54,6 +54,10 @@ pub enum OpCode {
     /// stack.
     #[display("OP_PUSH_DATA3")]
     PushData4 = OP_PUSHDATA4,
+
+    /// Push the array `0x01` onto the stack.
+    #[display("OP_PUSHNUM_1")]
+    PushNum1 = OP_PUSHNUM_1,
 }
 
 #[derive(Wrapper, WrapperMut, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, From, Default)]


### PR DESCRIPTION
Hi @dr-orlovsky, 

I tried to validate the Tapret-based consignment with 'rgb cli' (version v0.10), and the command line returned the following error:


```
thread 'main' panicked at 'full range of u8 is covered: VariantError(Some(TypeName("OpCode")), 81)', /home/crisdut/.cargo/registry/src/github.com-1ecc6299db9ec823/bp-primitives-0.10.0/src/segwit.rs:153:38
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```   

After investigating, I noticed the problem:

When we try check if `script_pubkey` is p2tr, the `WitnessVer::V1.op_code()` fails because the OP_PUSHNUM_1 is missing.


This PR fixes that!