### PR TITLE
Update with new id string representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ name = "bp-seals"
 version = "0.10.5"
 dependencies = [
  "amplify",
- "baid58 0.3.2",
+ "baid58 0.4.1",
  "bp-dbc",
  "bp-primitives",
  "commit_verify",

--- a/seals/Cargo.toml
+++ b/seals/Cargo.toml
@@ -21,7 +21,7 @@ amplify = { workspace = true }
 single_use_seals = { workspace = true }
 commit_verify = { workspace = true }
 strict_encoding = { workspace = true }
-baid58 = "0.3.0"
+baid58 = "0.4.1"
 bp-primitives = { version = "0.10.5", path = "../primitives" }
 bp-dbc = { version = "0.10.5", path = "../dbc" }
 rand = "0.8.5"


### PR DESCRIPTION
- Use Baid58 v0.4 ids
- Use string representation for secret seals
- Add tests for SecretSeal::from_str