### PR TITLE
Improvements and fixes for primitive types

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -41,6 +41,11 @@ pub struct BlockHash(
 impl_sha256d_hashtype!(BlockHash, "BlockHash");
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
 pub struct BlockHeader {
     /// Block version, now repurposed for soft fork signalling.
     pub version: i32,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -60,7 +60,10 @@ pub use block::{BlockHash, BlockHeader};
 pub use script::{OpCode, ScriptPubkey, SigScript};
 pub use segwit::*;
 pub use taproot::*;
-pub use tx::{LockTime, Outpoint, Sats, SeqNo, Tx, TxIn, TxOut, TxVer, Txid, Vout, Witness};
+pub use tx::{
+    LockTime, Outpoint, OutpointParseError, Sats, SeqNo, Tx, TxIn, TxOut, TxVer, Txid, Vout,
+    Witness,
+};
 pub use types::{ScriptBytes, VarIntArray};
 pub use util::{Chain, NonStandardValue};
 

--- a/primitives/src/segwit.rs
+++ b/primitives/src/segwit.rs
@@ -149,8 +149,26 @@ impl WitnessVer {
     /// If the witness version number exceeds 16, errors with
     /// [`SegwitError::MalformedWitnessVersion`].
     pub fn from_version_no(no: u8) -> Result<Self, SegwitError> {
-        let op = OpCode::try_from(no).map_err(|_| SegwitError::MalformedWitnessVersion)?;
-        Self::from_op_code(op)
+        Ok(match no {
+            v if v == Self::V0.version_no() => Self::V0,
+            v if v == Self::V1.version_no() => Self::V1,
+            v if v == Self::V2.version_no() => Self::V2,
+            v if v == Self::V3.version_no() => Self::V3,
+            v if v == Self::V4.version_no() => Self::V4,
+            v if v == Self::V5.version_no() => Self::V5,
+            v if v == Self::V6.version_no() => Self::V6,
+            v if v == Self::V7.version_no() => Self::V7,
+            v if v == Self::V8.version_no() => Self::V8,
+            v if v == Self::V9.version_no() => Self::V9,
+            v if v == Self::V10.version_no() => Self::V10,
+            v if v == Self::V11.version_no() => Self::V11,
+            v if v == Self::V12.version_no() => Self::V12,
+            v if v == Self::V13.version_no() => Self::V13,
+            v if v == Self::V14.version_no() => Self::V14,
+            v if v == Self::V15.version_no() => Self::V15,
+            v if v == Self::V16.version_no() => Self::V16,
+            _ => return Err(SegwitError::InvalidWitnessVersion(no)),
+        })
     }
 
     /// Converts [`WitnessVer`] instance into corresponding Bitcoin op-code.

--- a/primitives/src/tx.rs
+++ b/primitives/src/tx.rs
@@ -160,7 +160,11 @@ impl Witness {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_BITCOIN)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
 pub struct TxIn {
     pub prev_output: Outpoint,
     pub sig_script: SigScript,
@@ -277,7 +281,11 @@ impl Display for Sats {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_BITCOIN)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
 pub struct TxOut {
     pub value: Sats,
     pub script_pubkey: ScriptPubkey,
@@ -339,7 +347,11 @@ impl LockTime {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_BITCOIN)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
 pub struct Tx {
     pub version: TxVer,
     pub inputs: VarIntArray<TxIn>,


### PR DESCRIPTION
As a part of my work on making sure that all RGB wallet-related tasks (including Tapret) are working as required I stumble upon issues and bugs, which are being progressively fixed in this branch