### PR TITLE
Rename primitives to consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,12 +164,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-consensus"
+version = "0.10.9"
+dependencies = [
+ "amplify",
+ "commit_verify",
+ "secp256k1",
+ "serde",
+ "strict_encoding",
+ "strict_types",
+]
+
+[[package]]
 name = "bp-core"
 version = "0.10.9"
 dependencies = [
  "amplify",
+ "bp-consensus",
  "bp-dbc",
- "bp-primitives",
  "bp-seals",
  "commit_verify",
  "serde",
@@ -184,23 +196,11 @@ version = "0.10.9"
 dependencies = [
  "amplify",
  "base85",
- "bp-primitives",
+ "bp-consensus",
  "commit_verify",
  "secp256k1",
  "serde",
  "strict_encoding",
-]
-
-[[package]]
-name = "bp-primitives"
-version = "0.10.9"
-dependencies = [
- "amplify",
- "commit_verify",
- "secp256k1",
- "serde",
- "strict_encoding",
- "strict_types",
 ]
 
 [[package]]
@@ -209,8 +209,8 @@ version = "0.10.9"
 dependencies = [
  "amplify",
  "baid58",
+ "bp-consensus",
  "bp-dbc",
- "bp-primitives",
  "commit_verify",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,12 @@ version = 3
 
 [[package]]
 name = "amplify"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add3e79c9c3e33209e1676562e0fda882bc20701f52870ba162d9f046b7d8b0b"
+checksum = "16a7164b219700bd9a4b8708bf4784b974d079c8c8b761b9f18a0c45ece214cb"
 dependencies = [
  "amplify_apfloat",
- "amplify_derive 3.0.1",
+ "amplify_derive",
  "amplify_num",
  "amplify_syn",
  "ascii",
@@ -29,18 +29,6 @@ checksum = "f5b7f29fad2a3def5dfbfed0da85b886eb927a18fe0296c06e39880b7a96db05"
 dependencies = [
  "amplify_num",
  "bitflags",
-]
-
-[[package]]
-name = "amplify_derive"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87df0f28e6eb1f2d355f29ba6793fa9ca643967528609608d5cbd70bd68f9d1"
-dependencies = [
- "amplify_syn",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -226,9 +214,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -315,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,7 +363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -380,15 +390,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mnemonic"
@@ -420,9 +436,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -509,7 +525,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -520,6 +536,15 @@ checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
  "serde",
 ]
 
@@ -539,7 +564,7 @@ version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -563,7 +588,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae7f7cb6a68cfc99674a70a47ab790c6ede965107cd0823ed814b5e73b3bee2"
 dependencies = [
- "amplify_derive 4.0.0-alpha.6",
+ "amplify_derive",
 ]
 
 [[package]]
@@ -600,7 +625,7 @@ dependencies = [
  "baid58",
  "base64",
  "half",
- "indexmap",
+ "indexmap 1.9.3",
  "sha2",
  "strict_encoding",
 ]
@@ -628,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -654,16 +679,41 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -717,7 +767,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -739,7 +789,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -749,3 +799,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "winnow"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "bp-consensus"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "amplify",
  "commit_verify",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "bp-core"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "amplify",
  "bp-consensus",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "bp-dbc"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "amplify",
  "base85",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "bp-seals"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "amplify",
  "baid58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-    "primitives",
+    "consensus",
     "dbc",
     "seals",
     "."
 ]
 default-members = [
-    "primitives",
+    "consensus",
     "dbc",
     "seals",
     "."
@@ -55,7 +55,7 @@ strict_encoding = { workspace = true }
 strict_types = { version = "1.6.0", optional = true }
 commit_verify = { workspace = true }
 single_use_seals = { workspace = true }
-bp-primitives = { version = "0.10.7", path = "./primitives" }
+bp-consensus = { version = "0.10.7", path = "consensus" }
 bp-dbc = { version = "0.10.9", path = "./dbc" }
 bp-seals = { version = "0.10.9", path = "./seals" }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
@@ -68,7 +68,7 @@ serde = [
     "bp-dbc/serde",
     "bp-seals/serde",
 ]
-stl = ["strict_types", "strict_types/base64", "bp-primitives/stl", "commit_verify/stl"]
+stl = ["strict_types", "strict_types/base64", "bp-consensus/stl", "commit_verify/stl"]
 
 [package.metadata.docs.rs]
 features = [ "all" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default-members = [
 ]
 
 [workspace.package]
+version = "0.10.10"
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 homepage = "https://github.com/BP-WG"
 repository = "https://github.com/BP-WG/bp-core"
@@ -28,7 +29,7 @@ single_use_seals = "0.10.0"
 
 [package]
 name = "bp-core"
-version = "0.10.9"
+version = { workspace = true }
 description = "Bitcoin protocol core library (BP Core Lib)"
 keywords = ["lnp-bp", "smart-contracts", "bitcoin", "blockchain"]
 categories = ["cryptography"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ default = []
 all = ["serde", "stl"]
 serde = [
     "serde_crate",
+    "bp-consensus/serde",
     "bp-dbc/serde",
     "bp-seals/serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,14 @@ license = "Apache-2.0"
 [workspace.dependencies]
 amplify = "4.2.0"
 strict_encoding = "2.5.0"
+strict_types = "1.6.2"
 commit_verify = "0.10.5"
 single_use_seals = "0.10.0"
+bp-consensus = { version = "0.10.10", path = "consensus" }
+bp-dbc = { version = "0.10.10", path = "./dbc" }
+bp-seals = { version = "0.10.10", path = "./seals" }
+secp256k1 = { version = "0.27.0", features = ["global-context"] }
+serde_crate = { package = "serde", version = "1", features = ["derive"] }
 
 [package]
 name = "bp-core"
@@ -53,13 +59,13 @@ required-features = ["stl"]
 [dependencies]
 amplify = { workspace = true }
 strict_encoding = { workspace = true }
-strict_types = { version = "1.6.0", optional = true }
+strict_types = { workspace = true, optional = true }
 commit_verify = { workspace = true }
 single_use_seals = { workspace = true }
-bp-consensus = { version = "0.10.7", path = "consensus" }
-bp-dbc = { version = "0.10.9", path = "./dbc" }
-bp-seals = { version = "0.10.9", path = "./seals" }
-serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+bp-consensus = { workspace = true }
+bp-dbc = { workspace = true }
+bp-seals = { workspace = true }
+serde_crate = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Detailed developer & API documentation for all libraries can be accessed at:
 - <https://docs.rs/bp-core/>
 - <https://docs.rs/bp-dbc/>
 - <https://docs.rs/bp-seals/>
-- <https://docs.rs/bp-primitives/>
+- <https://docs.rs/bp-consensus/>
 
 To learn about the technologies enabled by the library please check
 [slides from our tech presentations][presentations] and
@@ -57,7 +57,7 @@ To use libraries, you just need latest version of libraries, published to
 `Cargo.toml`. Here is the full list of available libraries from this repository:
 
 ```toml
-bp-primitives = "1" # Bitcoin protocol primitives crate
+bp-consensus = "1" # Bitcoin protocol consensus crate
 bp-dbc = "1" # Deterministic bitcoin commitments crate
 bp-seals = "1" # Bitcoin single-use-seals crate
 bp-core = "1" # Library including both of the previous crates

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp-consensus"
-version = "0.10.9"
+version = { workspace = true }
 description = "Bitcoin protocol consensus library"
 keywords = ["lnp-bp", "smart-contracts", "bitcoin", "blockchain"]
 categories = ["cryptography"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "bp-primitives"
+name = "bp-consensus"
 version = "0.10.9"
-description = "Bitcoin protocol primitives library"
+description = "Bitcoin protocol consensus library"
 keywords = ["lnp-bp", "smart-contracts", "bitcoin", "blockchain"]
 categories = ["cryptography"]
 authors = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -17,11 +17,11 @@ name = "bc"
 
 [dependencies]
 amplify = { workspace = true }
-secp256k1 = { version = "0.27.0", features = ["global-context"] }
 strict_encoding = { workspace = true }
-strict_types = { version = "1.6.2", optional = true }
+strict_types = { workspace = true, optional = true }
 commit_verify = { workspace = true }
-serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+secp256k1 = { workspace = true }
+serde_crate = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/coding.rs
+++ b/consensus/src/coding.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/opcodes.rs
+++ b/consensus/src/opcodes.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/script.rs
+++ b/consensus/src/script.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/segwit.rs
+++ b/consensus/src/segwit.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/sigtypes.rs
+++ b/consensus/src/sigtypes.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/stl.rs
+++ b/consensus/src/stl.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/taproot.rs
+++ b/consensus/src/taproot.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/tx.rs
+++ b/consensus/src/tx.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/util.rs
+++ b/consensus/src/util.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/consensus/src/weights.rs
+++ b/consensus/src/weights.rs
@@ -1,4 +1,4 @@
-// Bitcoin protocol primitives library.
+// Bitcoin protocol consensus library.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/dbc/Cargo.toml
+++ b/dbc/Cargo.toml
@@ -21,9 +21,9 @@ amplify = { workspace = true }
 base85 = "=2.0.0"
 strict_encoding = { workspace = true }
 commit_verify = { workspace = true, features = ["rand"] }
-bp-consensus = { version = "0.10.6", path = "../consensus" }
-secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std"] }
-serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+bp-consensus = { workspace = true }
+secp256k1 = { workspace = true, features = ["global-context", "rand-std"] }
+serde_crate = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/dbc/Cargo.toml
+++ b/dbc/Cargo.toml
@@ -21,7 +21,7 @@ amplify = { workspace = true }
 base85 = "=2.0.0"
 strict_encoding = { workspace = true }
 commit_verify = { workspace = true, features = ["rand"] }
-bp-primitives = { version = "0.10.6", path = "../primitives" }
+bp-consensus = { version = "0.10.6", path = "../consensus" }
 secp256k1 = { version = "0.27.0", features = ["global-context", "rand-std"] }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 
@@ -30,7 +30,7 @@ default = []
 all = ["serde"]
 serde = [
     "serde_crate",
-    "bp-primitives/serde",
+    "bp-consensus/serde",
     "commit_verify/serde",
     "secp256k1/serde"
 ]

--- a/dbc/Cargo.toml
+++ b/dbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp-dbc"
-version = "0.10.9"
+version = { workspace = true }
 description = "Deterministic bitcoin commitments library"
 keywords = ["lnp-bp", "bitcoin", "blockchain", "smart-contracts", "single-use-seals"]
 categories = ["cryptography", "encoding"]

--- a/seals/Cargo.toml
+++ b/seals/Cargo.toml
@@ -22,7 +22,7 @@ single_use_seals = { workspace = true }
 commit_verify = { workspace = true }
 strict_encoding = { workspace = true }
 baid58 = "0.4.4"
-bp-primitives = { version = "0.10.7", path = "../primitives" }
+bp-consensus = { version = "0.10.7", path = "../consensus" }
 bp-dbc = { version = "0.10.9", path = "../dbc" }
 rand = "0.8.5"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }

--- a/seals/Cargo.toml
+++ b/seals/Cargo.toml
@@ -22,10 +22,10 @@ single_use_seals = { workspace = true }
 commit_verify = { workspace = true }
 strict_encoding = { workspace = true }
 baid58 = "0.4.4"
-bp-consensus = { version = "0.10.7", path = "../consensus" }
-bp-dbc = { version = "0.10.9", path = "../dbc" }
+bp-consensus = { workspace = true }
+bp-dbc = { workspace = true }
 rand = "0.8.5"
-serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+serde_crate = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/seals/Cargo.toml
+++ b/seals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp-seals"
-version = "0.10.9"
+version = { workspace = true }
 description = "Bitcoin protocol single-use-seals library"
 keywords = ["lnp-bp", "bitcoin", "blockchain", "smart-contracts", "single-use-seals"]
 categories = ["cryptography", "encoding"]

--- a/seals/Cargo.toml
+++ b/seals/Cargo.toml
@@ -30,7 +30,13 @@ serde_crate = { package = "serde", version = "1", features = ["derive"], optiona
 [features]
 default = []
 all = ["serde"]
-serde = ["amplify/serde", "commit_verify/serde", "bp-dbc/serde", "serde_crate"]
+serde = [
+    "amplify/serde",
+    "commit_verify/serde",
+    "bp-consensus/serde",
+    "bp-dbc/serde",
+    "serde_crate"
+]
 
 [package.metadata.docs.rs]
 features = [ "all" ]


### PR DESCRIPTION
Primitives library was originally created to present only those Bitcoin consensus-level data structures which were used in RGB Core.

However, work on wallet-level libraries had required implementing all other data types which may be found in blocks (i.e. part of the consensus layer) - as well as doing encoding for such structures (without it it won't be possible to prepare and publish a new transaction). This library was a natural place for putting this stuff - since once implemented it must never change unless bitcoin consensus rules change with a new soft fork - or a bug is discovered. These are the exact same conditions under which `BP Core` operates and ossifies, thus, now we have `bp-primitives` working with all bitcoin consensus-level tasks (aside from validation), and it was quite natural to rename the library.

Now, this `bp-consensus` crate is an alternative to `rust-bitcoin` `consensus` module - but unlike `rust-bitcoin` these part will maintain immutable and ossified API and are clearly separated from wallet parts (PSBTs, BIP32, addresses etc) which change and evolve all the time.

CC @zoedberg @crisdut @cryptoquick